### PR TITLE
Add additional processing for SmiHandlerRegister service call (#17)

### DIFF
--- a/efiXplorer/efiSmmUtils.h
+++ b/efiXplorer/efiSmmUtils.h
@@ -43,3 +43,4 @@ std::vector<ea_t> findSmmGetVariableCalls(std::vector<segment_t *> dataSegments,
 std::vector<ea_t> resolveEfiSmmCpuProtocol(std::vector<json> stackGuids,
                                            std::vector<json> dataGuids,
                                            std::vector<json> *allServices);
+void markSmiHandler(ea_t ea);

--- a/efiXplorer/efiUtils.cpp
+++ b/efiXplorer/efiUtils.cpp
@@ -580,3 +580,30 @@ std::string getHex(uint64_t value) {
     snprintf(hexstr, 21, "%llX", value);
     return static_cast<std::string>(hexstr);
 }
+
+//--------------------------------------------------------------------------
+// Make sure the first argument looks like protocol
+bool bootServiceProtCheck(ea_t callAddr) {
+    bool valid = false;
+    insn_t insn;
+    auto addr = prev_head(callAddr, 0);
+    decode_insn(&insn, addr);
+    while (!is_basic_block_end(insn, false)) {
+
+        // for next iteration
+        decode_insn(&insn, addr);
+        addr = prev_head(addr, 0);
+
+        // check current instruction
+        if (insn.itype == NN_lea && insn.ops[0].type == o_reg &&
+            insn.ops[0].reg == REG_RCX) {
+            if (insn.ops[1].type == o_mem) {
+                // will still be a false positive if the Handle in
+                // SmmInstallProtocolInterface is a global variable)
+                valid = true;
+            }
+            break;
+        }
+    }
+    return valid;
+}

--- a/efiXplorer/efiUtils.h
+++ b/efiXplorer/efiUtils.h
@@ -191,6 +191,9 @@ json getGuidByAddr(ea_t addr);
 // Validate GUID value
 bool checkGuid(json guid);
 
+// Make sure the first argument looks like protocol
+bool bootServiceProtCheck(ea_t callAddr);
+
 // Convert GUID value to string
 std::string getGuidFromValue(json guid);
 

--- a/efiXplorer/tables/efi_services.h
+++ b/efiXplorer/tables/efi_services.h
@@ -227,8 +227,9 @@ struct pServicePush bootServicesTable32[] = {
 size_t bootServicesTable32Length = sizeof(bootServicesTable64) / sizeof(pServicePush);
 
 struct service bootServicesTableAll[] = {
-    {"RaiseTPL", RaiseTPLOffset64, RaiseTPLOffset32},
-    {"RestoreTPL", RestoreTPLOffset64, RestoreTPLOffset32},
+    // difficult to check false positives
+    // {"RaiseTPL", RaiseTPLOffset64, RaiseTPLOffset32},
+    // {"RestoreTPL", RestoreTPLOffset64, RestoreTPLOffset32},
     {"AllocatePages", AllocatePagesOffset64, AllocatePagesOffset32},
     {"FreePages", FreePagesOffset64, FreePagesOffset32},
     {"GetMemoryMap", GetMemoryMapOffset64, GetMemoryMapOffset32},


### PR DESCRIPTION
Add additional processing for SmiHandlerRegister service call (#17), fix a few bugs:

* add additional check for gBS->RegisterProtocolNotify (in some cases, efiXplorer confuses with gSmst->SmmInstallProtocolInterface)
* remove RaiseTPL, RestoreTPL (will be marked only in the code, but not in services chooser)
* add search for arguments (in case of protocols) only in a basic block