### PR TITLE
bugfix. process_section_entry will crash on segm_names.pop_back() while segm_name_len is 0.

### DIFF
--- a/efiXloader/pe.cpp
+++ b/efiXloader/pe.cpp
@@ -328,7 +328,15 @@ ea_t efiloader::PE::process_section_entry(ea_t next_ea) {
     set_cmt(next_ea, "Name", 0);
     op_hex(next_ea, 0);
     size_t segm_name_len = get_max_strlit_length(next_ea, STRTYPE_C);
-    get_strlit_contents(&segm_names.push_back(), next_ea, segm_name_len, STRTYPE_C);
+
+    if(segm_name_len){
+        get_strlit_contents(&segm_names.push_back(), next_ea, segm_name_len, STRTYPE_C);
+    }
+    else{
+        //if the segm_name_len is 0, it will trigger a crash on segm_names.pop_back() later.
+        segm_names.push_back("UNKNOW");
+    }
+    
     next_ea += 8;
     create_dword(next_ea, 4);
     set_cmt(next_ea, "Virtual size", 0);


### PR DESCRIPTION
Fix the crash on macOS big sur 11.5.2.


Process:               ida64 [20792]
Path:                  /Applications/IDA Pro 7.6/ida64.app/Contents/MacOS/ida64
Identifier:            com.hexrays.ida64
Version:               7.6.210427 (210427)
Code Type:             X86-64 (Native)
Parent Process:        ??? [1]
Responsible:           ida64 [20792]
User ID:               501

Date/Time:             2021-09-08 14:22:00.907 +0800
OS Version:            macOS 11.5.2 (20G95)
Report Version:        12
Bridge OS Version:     5.5 (18P4759a)
Anonymous UUID:        FEF90742-37E6-36D8-350F-C518A2B8CBB5

Sleep/Wake UUID:       55334475-F1D2-4BB2-AF2F-831D29C94BF0

Time Awake Since Boot: 330000 seconds
Time Since Wake:       5800 seconds

System Integrity Protection: enabled

Crashed Thread:        0  Dispatch queue: com.apple.main-thread

Exception Type:        EXC_CRASH (SIGABRT)
Exception Codes:       0x0000000000000000, 0x0000000000000000
Exception Note:        EXC_CORPSE_NOTIFY

Application Specific Information:
abort() called
ida64(20792,0x112f14e00) malloc: *** error for object 0x6000024e8980: pointer being freed was not allocated
 

Thread 0 Crashed:: Dispatch queue: com.apple.main-thread
0   libsystem_kernel.dylib        	0x00007fff204e392e __pthread_kill + 10
1   libsystem_pthread.dylib       	0x00007fff205125bd pthread_kill + 263
2   libsystem_c.dylib             	0x00007fff20467406 abort + 125
3   libsystem_malloc.dylib        	0x00007fff20347165 malloc_vreport + 548
4   libsystem_malloc.dylib        	0x00007fff2034a2aa malloc_report + 151
5   libida64.dylib                	0x0000000103eb920a validate_input_str(_qstring<char>*, vis_code_t (*)(void*, unsigned int, unsigned int, char const*, char*, char const*), void*, int) + 2026

Thread 1:
0   libsystem_pthread.dylib       	0x00007fff2050e420 start_wqthread + 0

Thread 2:
0   libsystem_pthread.dylib       	0x00007fff2050e420 start_wqthread + 0

Thread 3:
0   libsystem_pthread.dylib       	0x00007fff2050e420 start_wqthread + 0

Thread 4:
0   libsystem_pthread.dylib       	0x00007fff2050e420 start_wqthread + 0

Thread 5:
0   libsystem_pthread.dylib       	0x00007fff2050e420 start_wqthread + 0
