### PR TITLE
Try to load guids.json from the per-user directory as well.

### DIFF
--- a/efiXplorer/efiAnalysis.cpp
+++ b/efiXplorer/efiAnalysis.cpp
@@ -60,9 +60,7 @@ std::vector<ea_t> smmGetVariableOverflow;
 
 efiAnalysis::efiAnalyzer::efiAnalyzer() {
     // get guids.json path
-    guidsJsonPath /= idadir("plugins");
-    guidsJsonPath /= "guids";
-    guidsJsonPath /= "guids.json";
+    guidsJsonPath /= getGuidsJsonFile();
 
     // get base address
     base = get_imagebase();

--- a/efiXplorer/efiUtils.cpp
+++ b/efiXplorer/efiUtils.cpp
@@ -322,11 +322,33 @@ void setPtrTypeAndName(ea_t ea, std::string name, std::string type) {
 //--------------------------------------------------------------------------
 // Check for guids.json file exist
 bool guidsJsonExists() {
+    return !getGuidsJsonFile().empty();
+}
+
+//--------------------------------------------------------------------------
+// Get guids.json file name
+std::filesystem::path getGuidsJsonFile() {
     std::filesystem::path guidsJsonPath;
     guidsJsonPath /= idadir("plugins");
     guidsJsonPath /= "guids";
     guidsJsonPath /= "guids.json";
-    return std::filesystem::exists(guidsJsonPath);
+    if (std::filesystem::exists(guidsJsonPath)) {
+        return guidsJsonPath;
+    }
+
+    // Try to load it from the per-user directory.
+    guidsJsonPath.clear();
+    guidsJsonPath /= get_user_idadir();
+    guidsJsonPath /= "plugins";
+    guidsJsonPath /= "guids";
+    guidsJsonPath /= "guids.json";
+    if (std::filesystem::exists(guidsJsonPath)) {
+        return guidsJsonPath;
+    }
+
+    // Does not exist.
+    guidsJsonPath.clear();
+    return guidsJsonPath;
 }
 
 //--------------------------------------------------------------------------

--- a/efiXplorer/efiUtils.h
+++ b/efiXplorer/efiUtils.h
@@ -154,6 +154,9 @@ void setPtrTypeAndName(ea_t ea, std::string name, std::string type);
 // Check for guids.json file exist
 bool guidsJsonExists();
 
+// Get guids.json file name
+std::filesystem::path getGuidsJsonFile();
+
 // Get json summary file name
 std::filesystem::path getSummaryFile();
 


### PR DESCRIPTION
This PR allows efiXplorer to use the per-user directory as a fallback when searching for the `guids.json` file.
The per-user directory has several important advantages over the "standard" plugins directory: it does not change with each new version of IDA, so plugins placed there are more likely to "survive" upgrades. In addition, no elevated privileges are required to write there.