### PR TITLE
Fix segment naming in efiXloader

### DIFF
--- a/efiXloader/pe.h
+++ b/efiXloader/pe.h
@@ -165,9 +165,9 @@ class PE {
     qvector<qstring> segm_names;
     qvector<qstring> secs_names;
     ea_t process_section_entry(ea_t ea);
-    segment_t *make_generic_segment(ea_t seg_ea, ea_t seg_ea_end, char *section_name,
+    segment_t *make_generic_segment(ea_t seg_ea, ea_t seg_ea_end, const char *section_name,
                                     uint32_t flags);
-    segment_t *make_head_segment(ea_t start, ea_t end, char *name);
+    segment_t *make_head_segment(ea_t start, ea_t end, const char *name);
     void setup_ds_selector();
 };
 } // namespace efiloader


### PR DESCRIPTION
Fixes a bug that causes efiXloader to create strange segment names, such as `_____` and `@p___`.

**Problem:**
When a `section_name` passed to `efiloader::PE::make_generic_segment` does not contain a dot ('.') it is modified to have an ".unkn" suffix, as below:

https://github.com/binarly-io/efiXplorer/blob/6f2b237e15fca0baad0c8c44a6890af6eb2ed533/efiXloader/pe.cpp#L276-L279

To do this, a new temporary `qstring` is constructed and `section_name` is updated to point to it. However, as the temporary string's destructor runs at the end of the if block, it causes the `section_name` pointer to become invalid, which leads to some segment names created by efiXloader to appear as gibberish.