### PR TITLE
Fix condition checks from REG_RAX to rt_reg

### DIFF
--- a/efiXplorer/efiAnalyzerX86.cpp
+++ b/efiXplorer/efiAnalyzerX86.cpp
@@ -797,7 +797,7 @@ void EfiAnalysis::EfiAnalyzerX86::getAllRuntimeServices() {
                     service_offset = insn.ops[1].addr;
                 }
 
-                if (insn.itype == NN_callni && insn.ops[0].reg == REG_RAX) {
+                if (insn.itype == NN_callni && insn.ops[0].reg == rt_reg) {
 
                     if (insn.ops[0].addr) {
                         service_offset = insn.ops[0].addr;


### PR DESCRIPTION
Hi guys,

Sometimes several `Runtime Services` can not be recognized correctly, as a result, some double GetVariable vulnerabilities may be missed. 

After some source code reading, I found the reason that when parsing xrefs of `gRT`, the condition checks `insn.ops[0].reg == REG_RAX`, which should be changed to `insn.ops[0].reg == rt_reg`.

Sometimes, `RuntimeServices` may be invoked via other registers like `r10` (the following example).

```assembly
mov     r10, cs:gRT
lea     rax, [rbp+57h+var_88]
lea     r9, [rbp+57h+DataSize] ; DataSize
lea     rdx, [rbp+57h+var_B0] ; VendorGuid
lea     rcx, VariableName ; "DynamicUpdateBuffer"
xor     r8d, r8d        ; Attributes
mov     [rbp+57h+DataSize], 0B000h
mov     [rsp+0F0h+Data], rax ; Data
call    [r10+EFI_RUNTIME_SERVICES.GetVariable] ; gRT->GetVariable()
                        ; EFI_STATUS(EFIAPI * EFI_GET_VARIABLE) (IN CHAR16 *VariableName, IN EFI_GUID *VendorGuid, OUT UINT32 *Attributes, OPTIONAL IN OUT UINTN *DataSize, OUT VOID *Data)
                        ; VariableName   A Null-terminated string that is the name of the vendor's variable.
                        ; VendorGuid     A unique identifier for the vendor.
                        ; Attributes     If not NULL, a pointer to the memory location to return the attributes bitmask for the variable.
                        ; DataSize       On input, the size in bytes of the return Data buffer. On output the size of data returned in Data.
                        ; Data           The buffer to return the contents of the variable.
mov     rsi, rax
test    rax, rax
jz      short loc_35B5B
```

I think this patch would improve the ability to find vulnerabilities.

Thanks