### PR TITLE
Fix build with Apple clang v15.0.0

### DIFF
--- a/build.py
+++ b/build.py
@@ -43,7 +43,6 @@ def build_plugin(idasdk: str, hexrays_sdk: str, batch: bool):
     if hexrays_sdk:
         print("[INFO] HexRays analysis will be enabled")
         command.append(f"-DHexRaysSdk_ROOT_DIR={hexrays_sdk}")
-    print(command)
     subprocess.call(command)
     subprocess.call(["cmake", "--build", ".", "--config", "Release", "--parallel"])
 

--- a/cmake/FindIdaSdk.cmake
+++ b/cmake/FindIdaSdk.cmake
@@ -121,8 +121,9 @@ function(_ida_plugin name ea64 link_script) # ARGN contains sources
   if(UNIX)
     target_compile_options(${t} PUBLIC ${_ida_compile_options})
     if(APPLE)
-      target_link_libraries(${t} ${_ida_compile_options} -Wl,-flat_namespace
-                            -Wl,-undefined,warning -Wl,-exported_symbol,_PLUGIN)
+      target_link_libraries(
+        ${t} ${_ida_compile_options} -Wl,-ld_classic -Wl,-flat_namespace
+        -Wl,-undefined,warning -Wl,-exported_symbol,_PLUGIN)
     else()
       # Always use the linker script needed for IDA.
       target_link_libraries(${t} ${_ida_compile_options} -Wl,--version-script
@@ -156,8 +157,9 @@ function(_ida_loader name ea64 link_script)
   if(UNIX)
     target_compile_options(${t} PUBLIC ${_ida_compile_options})
     if(APPLE)
-      target_link_libraries(${t} ${_ida_compile_options} -Wl,-flat_namespace
-                            -Wl,-undefined,warning -Wl,-exported_symbol,_LDSC)
+      target_link_libraries(
+        ${t} ${_ida_compile_options} -Wl,-ld_classic -Wl,-flat_namespace
+        -Wl,-undefined,warning -Wl,-exported_symbol,_LDSC)
     else()
       # Always use the linker script needed for IDA.
       target_link_libraries(${t} ${_ida_compile_options} -Wl,--version-script


### PR DESCRIPTION
The apple developer tools update (https://developer.apple.com/documentation/xcode-release-notes/xcode-15-release-notes) includes updates to the linker, with which the plugin and loader build breaks down.

This PR will allow us to build it in "compatibility mode" using `-ld_classic` option for AppleClang v15.0.0 and higher.