### PR TITLE
import MACRO_VARIABLE_ATTRIBUTE

### DIFF
--- a/efiXplorer/efi_analysis.h
+++ b/efiXplorer/efi_analysis.h
@@ -129,6 +129,8 @@ protected:
   ea_list_t m_double_get_variable_smm;
   ea_list_t m_double_get_variable;
 
+  tid_t m_macro_efi_tid;
+
   // mask and masked value for MACRO_EFI enum value detection
   uint64_t m_mask = 0;
   uint64_t m_masked_value = 0;
@@ -413,10 +415,6 @@ public:
   void show_all_choosers();
 
 private:
-  tid_t m_macro_efi_tid;
-  uint64_t m_mask = 0;
-  uint64_t m_masked_value = 0;
-
   bool install_multiple_prot_interfaces_analyser();
   bool set_enums_repr(ea_t ea, insn_t insn);
   void find_callout_rec(func_t *func);

--- a/efiXplorer/efi_analysis.h
+++ b/efiXplorer/efi_analysis.h
@@ -373,6 +373,7 @@ public:
     import_type(idati, -1, "EFI_PEI_SERVICES");
     import_type(idati, -1, "EFI_PEI_READ_ONLY_VARIABLE2_PPI");
     import_type(idati, -1, "EFI_SMM_VARIABLE_PROTOCOL");
+    import_type(idati, -1, "MACRO_VARIABLE_ATTRIBUTE");
 
     tinfo_t tinfo;
     if (tinfo.get_named_type(idati, "MACRO_EFI")) {
@@ -433,6 +434,7 @@ public:
     import_type(idati, -1, "EFI_HANDLE");
     import_type(idati, -1, "EFI_RUNTIME_SERVICES");
     import_type(idati, -1, "EFI_SYSTEM_TABLE");
+    import_type(idati, -1, "MACRO_VARIABLE_ATTRIBUTE");
 
     tinfo_t tinfo;
     if (tinfo.get_named_type(idati, "MACRO_EFI")) {


### PR DESCRIPTION
Import the `MACRO_VARIABLE_ATTRIBUTE` enum. It will allow us to quickly annotate the `Attributes` argument for `gRT->SetVariable()` (with `m` key):

```c
gRT->SetVariable(L"EnableHIPM", &UNKNOWN_PROTOCOL_GUID, VARIABLE_ATTRIBUTE_NV_BS_RT, 4uLL, &gEnableHIPM);
```

As attributes are most often assigned in the following way (due to optimisations):

```asm
mov     r9d, 4          ; DataSize
lea     r8d, [r9+3]     ; Attributes
```

`op_enum` will not work, without using hex-rays or overwriting types from `uefi` til file.