### PR TITLE
annotate Attributes argument for SetVariable() when possible

### DIFF
--- a/cmake/FindIdaSdk.cmake
+++ b/cmake/FindIdaSdk.cmake
@@ -59,12 +59,6 @@
 include(CMakeParseArguments)
 include(FindPackageHandleStandardArgs)
 
-option(USE_LD_CLASSIC "Use -ld_classic option" OFF)
-if(CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang"
-   AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "15.0.0")
-  set(USE_LD_CLASSIC ON)
-endif()
-
 find_path(
   IdaSdk_DIR
   NAMES include/pro.h
@@ -137,15 +131,9 @@ function(_ida_plugin name ea64 link_script) # ARGN contains sources
   if(UNIX)
     target_compile_options(${t} PUBLIC ${_ida_compile_options})
     if(APPLE)
-      if(USE_LD_CLASSIC)
-        target_link_libraries(
-          ${t} ${_ida_compile_options} -Wl,-ld_classic -Wl,-flat_namespace
-          -Wl,-undefined,warning -Wl,-exported_symbol,_PLUGIN)
-      else()
-        target_link_libraries(
-          ${t} ${_ida_compile_options} -Wl,-flat_namespace
-          -Wl,-undefined,warning -Wl,-exported_symbol,_PLUGIN)
-      endif()
+      target_link_libraries(
+        ${t} ${_ida_compile_options} -Wl,-flat_namespace
+        -Wl,-undefined,dynamic_lookup -Wl,-exported_symbol,_PLUGIN)
     else()
       # Always use the linker script needed for IDA.
       target_link_libraries(${t} ${_ida_compile_options} -Wl,--version-script
@@ -180,14 +168,9 @@ function(_ida_loader name ea64 link_script)
   if(UNIX)
     target_compile_options(${t} PUBLIC ${_ida_compile_options})
     if(APPLE)
-      if(USE_LD_CLASSIC)
-        target_link_libraries(
-          ${t} ${_ida_compile_options} -Wl,-ld_classic -Wl,-flat_namespace
-          -Wl,-undefined,warning -Wl,-exported_symbol,_LDSC)
-      else()
-        target_link_libraries(${t} ${_ida_compile_options} -Wl,-flat_namespace
-                              -Wl,-undefined,warning -Wl,-exported_symbol,_LDSC)
-      endif()
+      target_link_libraries(
+        ${t} ${_ida_compile_options} -Wl,-flat_namespace
+        -Wl,-undefined,dynamic_lookup -Wl,-exported_symbol,_LDSC)
     else()
       # Always use the linker script needed for IDA.
       target_link_libraries(${t} ${_ida_compile_options} -Wl,--version-script

--- a/efiXloader/CMakeLists.txt
+++ b/efiXloader/CMakeLists.txt
@@ -19,6 +19,10 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
       "${CMAKE_CXX_FLAGS} -Wno-nullability-completeness -Wno-varargs")
 endif()
 
+if(NOT MSVC)
+  add_compile_options(-O3 -flto)
+endif()
+
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/../cmake)
 
 find_package(IdaSdk REQUIRED)

--- a/efiXplorer/CMakeLists.txt
+++ b/efiXplorer/CMakeLists.txt
@@ -18,6 +18,10 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
       "${CMAKE_CXX_FLAGS} -Wno-nullability-completeness -Wno-varargs")
 endif()
 
+if(NOT MSVC)
+  add_compile_options(-O3 -flto)
+endif()
+
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/../cmake)
 
 find_package(IdaSdk REQUIRED)

--- a/efiXplorer/efi_analysis.h
+++ b/efiXplorer/efi_analysis.h
@@ -130,6 +130,7 @@ protected:
   ea_list_t m_double_get_variable;
 
   tid_t m_macro_efi_tid;
+  tid_t m_macro_var_attr_tid;
 
   // mask and masked value for MACRO_EFI enum value detection
   uint64_t m_mask = 0;
@@ -373,14 +374,8 @@ public:
     import_type(idati, -1, "EFI_PEI_SERVICES");
     import_type(idati, -1, "EFI_PEI_READ_ONLY_VARIABLE2_PPI");
     import_type(idati, -1, "EFI_SMM_VARIABLE_PROTOCOL");
-    import_type(idati, -1, "MACRO_VARIABLE_ATTRIBUTE");
-
-#if IDA_SDK_VERSION >= 900
-    tinfo_t tinfo;
-    if (tinfo.get_named_type(idati, "MACRO_EFI")) {
-      m_macro_efi_tid = tinfo.force_tid();
-    }
-#endif
+    m_macro_efi_tid = import_type(idati, -1, "MACRO_EFI");
+    m_macro_var_attr_tid = import_type(idati, -1, "MACRO_VARIABLE_ATTRIBUTE");
 
 #ifdef HEX_RAYS
     for (auto idx = 0; idx < get_entry_qty(); idx++) {
@@ -436,14 +431,8 @@ public:
     import_type(idati, -1, "EFI_HANDLE");
     import_type(idati, -1, "EFI_RUNTIME_SERVICES");
     import_type(idati, -1, "EFI_SYSTEM_TABLE");
-    import_type(idati, -1, "MACRO_VARIABLE_ATTRIBUTE");
-
-#if IDA_SDK_VERSION >= 900
-    tinfo_t tinfo;
-    if (tinfo.get_named_type(idati, "MACRO_EFI")) {
-      m_macro_efi_tid = tinfo.force_tid();
-    }
-#endif
+    m_macro_efi_tid = import_type(idati, -1, "MACRO_EFI");
+    m_macro_var_attr_tid = import_type(idati, -1, "MACRO_VARIABLE_ATTRIBUTE");
   }
 
   ~efi_analyser_arm_t() {
@@ -469,6 +458,7 @@ private:
   ea_list_t m_rt_list_arm;
 
   tid_t m_macro_efi_tid;
+  tid_t m_macro_var_attr_tid;
 
   bool get_protocol(ea_t address, uint32_t p_reg, std::string service_name);
   bool set_enums_repr(ea_t ea, insn_t insn);

--- a/efiXplorer/efi_analysis_x86.cc
+++ b/efiXplorer/efi_analysis_x86.cc
@@ -2375,8 +2375,18 @@ bool efi_analysis::efi_analyser_t::analyse_variable_service(
   addr = args[2]; // Attributes argument
   decode_insn(&insn, addr);
 
-  // attempt to annotate Attributes argument
-  op_enum(addr, 1, m_macro_var_attr_tid, 0);
+  if (insn.itype == NN_mov && insn.ops[1].type == o_imm) {
+    // attempt to annotate Attributes argument
+    //
+    // mostly we see such code where op_enum() does not
+    // help, because operand is not an immediate value:
+    // mov r9d, X      ; DataSize
+    // lea r8d, [r9+Y] ; Attributes (X + Y)
+    //
+    // however, it will work when we encounter:
+    // mov r8d, X      ; Attributes
+    op_enum(addr, 1, m_macro_var_attr_tid, 0);
+  }
 
   if (insn.itype == NN_xor && insn.ops[0].type == o_reg &&
       insn.ops[1].type == o_reg && insn.ops[0].reg == insn.ops[1].reg &&

--- a/efiXplorer/efi_analysis_x86.cc
+++ b/efiXplorer/efi_analysis_x86.cc
@@ -2372,8 +2372,11 @@ bool efi_analysis::efi_analyser_t::analyse_variable_service(
       {0x00000008, "HARDWARE_ERROR_RECORD"},
       {0x00000010, "AUTHENTICATED_WRITE_ACCESS"}};
 
-  addr = args[2]; // attributes argument
+  addr = args[2]; // Attributes argument
   decode_insn(&insn, addr);
+
+  // attempt to annotate Attributes argument
+  op_enum(addr, 1, m_macro_var_attr_tid, 0);
 
   if (insn.itype == NN_xor && insn.ops[0].type == o_reg &&
       insn.ops[1].type == o_reg && insn.ops[0].reg == insn.ops[1].reg &&


### PR DESCRIPTION
Mostly we see such code where `op_enum()` does not help, because operand is not an immediate value:

```
mov r9d, X      ; DataSize
lea r8d, [r9+Y] ; Attributes (X + Y)
```

However, it will work when we encounter:

```
mov r8d, X      ; Attributes
```

In such cases we will get:

```c
gRT->SetVariable(L"CheckUserPSW", &VendorGuid, VARIABLE_ATTRIBUTE_NV_BS_RT, DataSize, &Data);
```

instead of:

```c
gRT->SetVariable(L"CheckUserPSW", &VendorGuid, 7u, DataSize, &Data);
```

Related PR: https://github.com/binarly-io/efiXplorer/pull/99